### PR TITLE
adds .gitattributes:

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary merge=union


### PR DESCRIPTION
- tells git that any file with the extension .pbxproj
should be treated as a binary